### PR TITLE
replace tsx prism indicator with jsx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 14.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Uses Node JS ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
         <img src="https://github.com/neel1996/langline/workflows/langline%20primray%20pipeline/badge.svg" />
         <img src="https://api.codacy.com/project/badge/Grade/851b4c5df5ac4ca89564dd773e57f589" />
         <a href="https://www.npmjs.com/package/@itassistors/langline" target="_blank">
-          <img src="https://img.shields.io/static/v1?label=langline&message=v1.0.1&color=brightgreen&logo=npm" />
+          <img src="https://img.shields.io/static/v1?label=langline&message=v1.0.2&color=brightgreen&logo=npm" />
         </a>
     </p>
 </p>

--- a/data/dataFile.json
+++ b/data/dataFile.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "tsx",
-      "indicationName": "tsx",
+      "indicationName": "jsx",
       "founder": "Jordan Walke",
       "firstRelease": 2013,
       "isActive": "TRUE",

--- a/data/langData.csv
+++ b/data/langData.csv
@@ -402,7 +402,7 @@ TI Program,.8xp|.8xk|.8xk.txt|.8xp.txt,,,1964
 TLA,.tla,,Leslie Lamport,1999
 TOML,.toml,toml,Preston-Werner,2013
 TSQL,.sql,,Donald D. Chamberlin Raymond F. Boyce,1974
-TSX,.tsx,tsx,Microsoft Corporation,2012
+TSX,.tsx,jsx,Microsoft Corporation,2012
 TXL,.txl,,James Cordy,1985
 Tcl,.tcl|.adp|.tm,tcl,John Ousterhout,1988
 Tcsh,.tcsh|.csh,,Ken Greer,1978

--- a/data/linguistDataSet.json
+++ b/data/linguistDataSet.json
@@ -2999,7 +2999,7 @@
     {
         "name": "TSX",
         "extensions": [".tsx"],
-        "prismIndicator": "tsx",
+        "prismIndicator": "jsx",
         "founder": ["Microsoft Corporation"],
         "year": ["2012"]
     },

--- a/data/linguistDataSet.ts
+++ b/data/linguistDataSet.ts
@@ -2969,7 +2969,7 @@ const languageDataSet: LangData[] = [
   {
     name: "TSX",
     extensions: [".tsx"],
-    prismIndicator: "tsx",
+    prismIndicator: "jsx",
     founder: ["Microsoft Corporation"],
     year: ["2012"],
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@itassistors/langline",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Node library to look up programming languages based on file extensions, file name and actual file",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
After building the gitconvex react app, prism fails to clone the JSX grammar for TSX. This commit replaces the prism indicator for tsx with jsx to resolve the issue 